### PR TITLE
Escape backticks

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ async function generateInjectCSS(sourcePath){
         if (!document.getElementById('${styleID}')) {
             var e = document.createElement('style');
             e.id = '${styleID}';
-            e.textContent = \`${sourceCSS}\`;
+            e.textContent = \`${sourceCSS.toString().replace(/`/g, '``')}\`;
             document.head.appendChild(e);
         }
     })();`;


### PR DESCRIPTION
This fixes a build error with files that contain backticks, this can happen when there are backticks in comments.